### PR TITLE
Resolve alpha-bugs for FilterCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -14,6 +14,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.PersonPredicate;
 
@@ -39,6 +40,8 @@ public class FilterCommand extends Command {
             + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "Bob "
             + PREFIX_PHONE + "90123445";
 
+    public static final String MESSAGE_INCOMPLETE_COMMAND = "Filter predicate cannot be empty.";
+
     private final PersonPredicate predicate;
 
     public FilterCommand(PersonPredicate predicate) {
@@ -46,7 +49,7 @@ public class FilterCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -66,9 +66,9 @@ public class FilterCommandParser implements Parser<FilterCommand> {
                 .flatMap(tag -> List.of(tag.trim().split("\\s+")).stream()).toList();
 
         // if either predicate is empty
-        if (names.contains("") || phones.contains("") || emails.contains("") || addresses.contains("") ||
-            registerNumbers.contains("") || sexes.contains("") || classes.contains("") || ecNames.contains("") ||
-            ecNumbers.contains("") || tags.contains("")) {
+        if (names.contains("") || phones.contains("") || emails.contains("") || addresses.contains("")
+                || registerNumbers.contains("") || sexes.contains("") || classes.contains("") || ecNames.contains("")
+                || ecNumbers.contains("") || tags.contains("")) {
             throw new ParseException(MESSAGE_INCOMPLETE_COMMAND);
         }
 

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.FilterCommand.MESSAGE_INCOMPLETE_COMMAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ECNAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ECNUMBER;
@@ -33,18 +34,45 @@ public class FilterCommandParser implements Parser<FilterCommand> {
                 args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
                 PREFIX_REGISTER_NUMBER, PREFIX_SEX, PREFIX_STUDENT_CLASS, PREFIX_ECNAME, PREFIX_ECNUMBER, PREFIX_TAG);
 
-        List<String> names = argMultimap.getAllValues(PREFIX_NAME).stream().map(String::trim).toList();
-        List<String> phones = argMultimap.getAllValues(PREFIX_PHONE).stream().map(String::trim).toList();
-        List<String> emails = argMultimap.getAllValues(PREFIX_EMAIL).stream().map(String::trim).toList();
-        List<String> addresses = argMultimap.getAllValues(PREFIX_ADDRESS).stream().map(String::trim).toList();
-        List<String> registerNumbers = argMultimap.getAllValues(PREFIX_REGISTER_NUMBER).stream()
-                .map(String::trim).toList();
-        List<String> sexes = argMultimap.getAllValues(PREFIX_SEX).stream().map(String::trim).toList();
-        List<String> classes = argMultimap.getAllValues(PREFIX_STUDENT_CLASS).stream().map(String::trim).toList();
-        List<String> ecNames = argMultimap.getAllValues(PREFIX_ECNAME).stream().map(String::trim).toList();
-        List<String> ecNumbers = argMultimap.getAllValues(PREFIX_ECNUMBER).stream().map(String::trim).toList();
-        List<String> tags = argMultimap.getAllValues(PREFIX_TAG).stream().map(String::trim).toList();
+        List<String> names = argMultimap.getAllValues(PREFIX_NAME).stream()
+                .flatMap(name -> List.of(name.trim().split("\\s+")).stream()).toList();
+        //split the names by spaces and flatmap it by putting all of them in one list
 
+        List<String> phones = argMultimap.getAllValues(PREFIX_PHONE).stream()
+                .flatMap(phone -> List.of(phone.trim().split("\\s+")).stream()).toList();
+
+        List<String> emails = argMultimap.getAllValues(PREFIX_EMAIL).stream()
+                .flatMap(email -> List.of(email.trim().split("\\s+")).stream()).toList();
+
+        List<String> addresses = argMultimap.getAllValues(PREFIX_ADDRESS).stream()
+                .flatMap(addr -> List.of(addr.trim().split("\\s+")).stream()).toList();
+
+        List<String> registerNumbers = argMultimap.getAllValues(PREFIX_REGISTER_NUMBER).stream()
+                .flatMap(regNo -> List.of(regNo.trim().split("\\s+")).stream()).toList();
+
+        List<String> sexes = argMultimap.getAllValues(PREFIX_SEX).stream()
+                .flatMap(sex -> List.of(sex.trim().split("\\s+")).stream()).toList();
+
+        List<String> classes = argMultimap.getAllValues(PREFIX_STUDENT_CLASS).stream()
+                .flatMap(clss -> List.of(clss.trim().split("\\s+")).stream()).toList();
+
+        List<String> ecNames = argMultimap.getAllValues(PREFIX_ECNAME).stream()
+                .flatMap(ecName -> List.of(ecName.trim().split("\\s+")).stream()).toList();
+
+        List<String> ecNumbers = argMultimap.getAllValues(PREFIX_ECNUMBER).stream()
+                .flatMap(ecNum -> List.of(ecNum.trim().split("\\s+")).stream()).toList();
+
+        List<String> tags = argMultimap.getAllValues(PREFIX_TAG).stream()
+                .flatMap(tag -> List.of(tag.trim().split("\\s+")).stream()).toList();
+
+        // if either predicate is empty
+        if (names.contains("") || phones.contains("") || emails.contains("") || addresses.contains("") ||
+            registerNumbers.contains("") || sexes.contains("") || classes.contains("") || ecNames.contains("") ||
+            ecNumbers.contains("") || tags.contains("")) {
+            throw new ParseException(MESSAGE_INCOMPLETE_COMMAND);
+        }
+
+        // if all predicates are empty
         if (names.isEmpty() && phones.isEmpty() && emails.isEmpty() && addresses.isEmpty()
                 && registerNumbers.isEmpty() && sexes.isEmpty() && classes.isEmpty()
                 && ecNames.isEmpty() && ecNumbers.isEmpty() && tags.isEmpty()) {


### PR DESCRIPTION
Bug 1 : Empty predicate
Fixes #136 
Fixes #152 
Fixes #154 
Fixes #155 
There is now an error message displayed on the console when a user tries to filter an empty predicate eg. filter n/ or filter p/. Nothing happens until the user rectifies the format of the command and inputs the correct command.

Bug 2 : Filter Command does not work or application crashes when the predicate contains spaces in between
Fixes #137 
Fixes #151 
Fixes #153 
All predicates can now be filtered even with spaces in between. Furthermore, multiple predicates can be given to filter multiple students at the same time now. For example, filter n/Alex Bernice displays both Alex and Bernice in the filtered list now.
