### PR TITLE
Branch resolve wrong error message

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddAttendanceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddAttendanceCommandParser.java
@@ -36,6 +36,11 @@ public class AddAttendanceCommandParser implements Parser<AddAttendanceCommand> 
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_ABSENT_DATE, PREFIX_ABSENT_REASON);
 
+        if (argMultimap.getPreamble().isEmpty()) {
+            logger.log(Level.WARNING, "Index for AddAttendanceCommand is missing.");
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddAttendanceCommand.MESSAGE_USAGE));
+        }
+
         if (!argMultimap.getValue(PREFIX_ABSENT_DATE).isPresent()
                 || !argMultimap.getValue(PREFIX_ABSENT_REASON).isPresent()) {
             logger.log(Level.WARNING, "Prefix for absent date or absent reason is missing.");

--- a/src/main/java/seedu/address/logic/parser/AddEcNameCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddEcNameCommandParser.java
@@ -31,6 +31,12 @@ public class AddEcNameCommandParser implements Parser<AddEcNameCommand> {
         logger.log(Level.INFO, "Parsing AddEcNameCommand with arguments");
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_ECNAME);
 
+        if (argMultimap.getPreamble().isEmpty()) {
+            logger.log(Level.WARNING, "EcName index is not present in the command.");
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddEcNameCommand.MESSAGE_USAGE));
+        }
+
         if (!argMultimap.getValue(PREFIX_ECNAME).isPresent()) {
             logger.log(Level.WARNING, "EcName prefix is not present in the command.");
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,

--- a/src/main/java/seedu/address/logic/parser/AddEcNumberCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddEcNumberCommandParser.java
@@ -30,6 +30,12 @@ public class AddEcNumberCommandParser implements Parser<AddEcNumberCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultiMap = ArgumentTokenizer.tokenize(args, PREFIX_ECNUMBER);
 
+        if (argMultiMap.getPreamble().isEmpty()) {
+            logger.log(Level.WARNING, "Index not present for AddEcNumberCommand.");
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddEcNumberCommand.MESSAGE_USAGE));
+        }
+
         if (!argMultiMap.getValue(PREFIX_ECNUMBER).isPresent()) {
             logger.log(Level.WARNING, "Prefix 'ep/' not present.");
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,

--- a/src/main/java/seedu/address/logic/parser/AddExamScoreCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddExamScoreCommandParser.java
@@ -11,6 +11,8 @@ import seedu.address.logic.commands.AddExamScoreCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.exam.Exam;
 
+import java.util.logging.Level;
+
 /**
  * Parses input arguments and creates a new {@code AddExamScoreCommand} object.
  */
@@ -24,6 +26,10 @@ public class AddExamScoreCommandParser implements Parser<AddExamScoreCommand> {
     public AddExamScoreCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_EXAM, PREFIX_EXAM_SCORE);
+
+        if (argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddExamScoreCommand.MESSAGE_USAGE));
+        }
 
         if (!argMultimap.getValue(PREFIX_EXAM).isPresent() || !argMultimap.getValue(PREFIX_EXAM_SCORE).isPresent()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddExamScoreCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/AddExamScoreCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddExamScoreCommandParser.java
@@ -11,8 +11,6 @@ import seedu.address.logic.commands.AddExamScoreCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.exam.Exam;
 
-import java.util.logging.Level;
-
 /**
  * Parses input arguments and creates a new {@code AddExamScoreCommand} object.
  */

--- a/src/main/java/seedu/address/logic/parser/AddSubmissionStatusCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddSubmissionStatusCommandParser.java
@@ -31,6 +31,12 @@ public class AddSubmissionStatusCommandParser implements Parser<AddSubmissionSta
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_SUBMISSION, PREFIX_SUBMISSION_STATUS);
 
+        if (argMultimap.getPreamble().isEmpty()) {
+            logger.log(Level.WARNING, "Missing index for AddSubmissionStatusCommand.");
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    AddSubmissionStatusCommand.MESSAGE_USAGE));
+        }
+
         if (!argMultimap.getValue(PREFIX_SUBMISSION).isPresent()
                 || !argMultimap.getValue(PREFIX_SUBMISSION_STATUS).isPresent()) {
             logger.log(Level.WARNING, "Missing prefix for AddSubmissionCommand or AddSubmissionStatusCommand.");

--- a/src/test/java/seedu/address/logic/parser/AddAttendanceParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddAttendanceParserTest.java
@@ -26,7 +26,7 @@ public class AddAttendanceParserTest {
     @Test
     public void parse_missingParts_failure() {
         // no index specified
-        assertParseFailure(parser, ATTENDANCE_DESC_AMY, MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, ATTENDANCE_DESC_AMY, MESSAGE_INVALID_FORMAT);
 
         // no field specified
         assertParseFailure(parser, "1", MESSAGE_INVALID_FORMAT);

--- a/src/test/java/seedu/address/logic/parser/AddEcNameCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddEcNameCommandParserTest.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ECNAME;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
@@ -44,13 +43,12 @@ public class AddEcNameCommandParserTest {
 
     @Test
     public void parse_missingParams_failure() {
-        String expectedIndexMessage = MESSAGE_INVALID_INDEX;
         String expectedParamMessage = MESSAGE_INVALID_FORMAT;
 
         // EP: no index
-        String userInput = AddEcNameCommand.COMMAND_WORD + " " + PREFIX_ECNAME
+        String userInput = AddEcNameCommand.COMMAND_WORD + PREFIX_ECNAME
                 + validEmergencyContactName;
-        assertParseFailure(parser, userInput, expectedIndexMessage);
+        assertParseFailure(parser, userInput, expectedParamMessage);
 
         // EP: no parameters
         userInput = AddEcNameCommand.COMMAND_WORD;

--- a/src/test/java/seedu/address/logic/parser/AddEcNameCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddEcNameCommandParserTest.java
@@ -46,12 +46,11 @@ public class AddEcNameCommandParserTest {
         String expectedParamMessage = MESSAGE_INVALID_FORMAT;
 
         // EP: no index
-        String userInput = AddEcNameCommand.COMMAND_WORD + PREFIX_ECNAME
-                + validEmergencyContactName;
+        String userInput = PREFIX_ECNAME + validEmergencyContactName;
         assertParseFailure(parser, userInput, expectedParamMessage);
 
         // EP: no parameters
-        userInput = AddEcNameCommand.COMMAND_WORD;
+        userInput = "";
         assertParseFailure(parser, userInput, expectedParamMessage);
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddExamScoreCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddExamScoreCommandParserTest.java
@@ -37,7 +37,7 @@ public class AddExamScoreCommandParserTest {
     @Test
     public void parse_missingParts_failure() {
         // no index specified
-        assertParseFailure(parser, EXAM_DESC_MIDTERM + EXAM_SCORE_DESC_AMY, MESSAGE_INVALID_INDEX);
+        assertParseFailure(parser, EXAM_DESC_MIDTERM + EXAM_SCORE_DESC_AMY, MESSAGE_INVALID_FORMAT);
 
         // no exam specified
         assertParseFailure(parser, INDEX_FIRST_PERSON.getOneBased() + EXAM_SCORE_DESC_AMY,

--- a/src/test/java/seedu/address/logic/parser/AddSubmissionStatusCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddSubmissionStatusCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_SUBMISSION_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_SUBMISSION_STATUS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.SUBMISSION_DESC_ASSIGNMENT;
 import static seedu.address.logic.commands.CommandTestUtil.SUBMISSION_STATUS_DESC_AMY;
@@ -8,6 +9,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_SUBMISSION_ASSI
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SUBMISSION_STATUS_AMY;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
+import static seedu.address.model.submission.Submission.NAME_MESSAGE_CONSTRAINTS;
 import static seedu.address.model.submission.Submission.STATUS_MESSAGE_CONSTRAINTS;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -18,6 +21,9 @@ import seedu.address.model.submission.Submission;
 
 public class AddSubmissionStatusCommandParserTest {
 
+    private static final String MESSAGE_INVALID_FORMAT = String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            AddSubmissionStatusCommand.MESSAGE_USAGE);
+
     private AddSubmissionStatusCommandParser parser = new AddSubmissionStatusCommandParser();
 
     @Test
@@ -26,6 +32,21 @@ public class AddSubmissionStatusCommandParserTest {
         AddSubmissionStatusCommand expectedCommand = new AddSubmissionStatusCommand(INDEX_FIRST_PERSON,
                 new Submission(VALID_SUBMISSION_ASSIGNMENT_1), VALID_SUBMISSION_STATUS_AMY);
         assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_missingParts_failure() {
+        // no index specified
+        assertParseFailure(parser, SUBMISSION_DESC_ASSIGNMENT + SUBMISSION_STATUS_DESC_AMY,
+                MESSAGE_INVALID_FORMAT);
+
+        // no submission specified
+        assertParseFailure(parser, INDEX_FIRST_PERSON.getOneBased() + SUBMISSION_STATUS_DESC_AMY,
+                MESSAGE_INVALID_FORMAT);
+
+        // no submission status specified
+        assertParseFailure(parser, INDEX_FIRST_PERSON.getOneBased() + SUBMISSION_DESC_ASSIGNMENT,
+                MESSAGE_INVALID_FORMAT);
     }
 
     @Test
@@ -43,6 +64,15 @@ public class AddSubmissionStatusCommandParserTest {
 
     @Test
     public void parse_invalidParams_failure() {
+        // invalid index
+        assertParseFailure(parser, "0" + SUBMISSION_DESC_ASSIGNMENT + SUBMISSION_STATUS_DESC_AMY,
+                MESSAGE_INVALID_INDEX);
+
+        // invalid submission name
+        assertParseFailure(parser, INDEX_FIRST_PERSON.getOneBased() + INVALID_SUBMISSION_DESC
+                + SUBMISSION_STATUS_DESC_AMY, NAME_MESSAGE_CONSTRAINTS);
+
+        // invalid submission status
         assertParseFailure(parser, INDEX_FIRST_PERSON.getOneBased() + SUBMISSION_DESC_ASSIGNMENT
                 + INVALID_SUBMISSION_STATUS_DESC, STATUS_MESSAGE_CONSTRAINTS);
     }


### PR DESCRIPTION
Resolves #298 

Command to run:
`addSubmissionStatus sm/A1 ss/Y`

Original error message received:
`Index is not a non-zero unsigned integer.`

This error message is wrong as the error is not that the index given is a non-zero integer, but rather that the index was not given in the first place.

Corrected error message:
```
Invalid command format!
addSubmissionStatus: Adds a submission status to a student identified by index.
Parameters: [INDEX] sm/SUBMISSION_NAME ss/SUBMISSION_STATUS
Example: addSubmissionStatus 1 sm/Assignment 1 ss/Y
```

Similar error messages provided for `addExamScore`, `addAttendance`, `addEcName` and `addEcNumber` commands are amended as well.