### PR TITLE
Fix rejecting invalid ecNumber inputs

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1098,7 +1098,7 @@ testers are expected to do more *exploratory* testing.
     3. Test case: `addEcNumber 1 ep/`<br>
        Expected: First student will have his emergency contact number deleted. Name of student with the emergency contact number deleted will be shown in the status message.
     
-    4. Test case: `addEcNumber 1 ep/123`<br>
+    4. Test case: `addEcNumber 1 ep/123 456`<br>
        Expected: No emergency contact number is changed. Error details shown in the status message.
 
     5. Other incorrect addEcNumber commands to try:<br> 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -233,7 +233,7 @@ Format: `addEcNumber INDEX ep/[ECNUMBER]`
 * Adds the emergency contact's number `ECNUMBER` to the person at the specified `INDEX`
 * Deletes the emergency contact's number at the specified `INDEX`
 * The index **must be a positive integer** 1, 2, 3, …​
-* The number **must be an 8 digit number** or **left empty**
+* The number **must be at least 3 digits** or **left empty**
 
 Examples:
 * `addEcNumber 1 ep/91234567` to add the emergency contact's number 91234567 to the 1st person in the list.

--- a/src/main/java/seedu/address/model/person/EcNumber.java
+++ b/src/main/java/seedu/address/model/person/EcNumber.java
@@ -11,9 +11,9 @@ public class EcNumber implements Comparable<EcNumber> {
 
     public static final String MESSAGE_GUI = "Emergency Contact Number: %1$s";
     public static final String MESSAGE_CONSTRAINTS =
-            "Emergency contact numbers should contain numbers that are 8 digits long\n"
+            "Emergency contact numbers should only contain numbers, and should be at least 3 digits long\n"
             + "and it can be blank if no contact number is provided.";
-    public static final String VALIDATION_REGEX = "\\d{8}";
+    public static final String VALIDATION_REGEX = "\\d{3,}";
 
     public final String value;
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -116,7 +116,7 @@ public class CommandTestUtil {
     public static final String INVALID_STUDENT_CLASS_DESC = " " + PREFIX_STUDENT_CLASS
             + "A1"; // wrong format used for student class
     public static final String INVALID_ECNAME_DESC = " " + PREFIX_ECNAME + "John%"; // "%" not allowed in ecname
-    public static final String INVALID_ECNUMBER_DESC = " " + PREFIX_ECNUMBER + "1234"; // 4 digit number
+    public static final String INVALID_ECNUMBER_DESC = " " + PREFIX_ECNUMBER + "+1234"; // "+" not allowed in ecnumber
     public static final String INVALID_SUBMISSION_DESC = " " + PREFIX_SUBMISSION + "Assignment #"; // "#" not allowed
     public static final String INVALID_SUBMISSION_STATUS_DESC = " " + PREFIX_SUBMISSION_STATUS
             + "T"; // only "Y", "N" and "NIL" allowed

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -40,7 +40,7 @@ public class ParserUtilTest {
     private static final String INVALID_SEX = "H";
     private static final String INVALID_STUDENT_CLASS = "A1";
     private static final String INVALID_EMERGENCY_CONTACT_NAME = "--";
-    private static final String INVALID_EMERGENCY_CONTACT_NUMBER = "1234";
+    private static final String INVALID_EMERGENCY_CONTACT_NUMBER = "+1234";
     private static final String INVALID_TAG = "#friend";
     private static final String INVALID_ABSENT_DATE = "2024-10-32"; // Invalid date
     private static final String INVALID_ABSENT_REASON = "";

--- a/src/test/java/seedu/address/model/person/EcNumberTest.java
+++ b/src/test/java/seedu/address/model/person/EcNumberTest.java
@@ -19,18 +19,18 @@ public class EcNumberTest {
 
     @Test
     public void constructor_invalidEcNumber_throwsIllegalArgumentException() {
-        String invalidEcNumber = "123";
+        String invalidEcNumber = "12";
         // EP: invalid EcNumber
         assertThrows(IllegalArgumentException.class, () -> new EcNumber(invalidEcNumber));
     }
 
     @Test
     public void constructor_validEcNumber() {
-        String validEcNumber1 = "12345678";
+        String validEcNumber1 = "123";
         String validEcNumber2 = "";
 
         // EP: valid EcNumber
-        assertDoesNotThrow(() -> new EcNumber(validEcNumber1)); // Boundary Value: 8 digits
+        assertDoesNotThrow(() -> new EcNumber(validEcNumber1)); // Boundary Value: 3 digits
         assertDoesNotThrow(() -> new EcNumber(validEcNumber2)); // Boundary Value: Empty String
     }
 
@@ -41,14 +41,14 @@ public class EcNumberTest {
 
         // EP: invalid phone numbers
         assertFalse(EcNumber.isValidEcNumber(" ")); // spaces only
-        assertFalse(EcNumber.isValidEcNumber("91")); // less than 8 numbers
+        assertFalse(EcNumber.isValidEcNumber("91")); // less than 3 digits
         assertFalse(EcNumber.isValidEcNumber("phone")); // non-numeric
         assertFalse(EcNumber.isValidEcNumber("9011p041")); // alphabets within digits
         assertFalse(EcNumber.isValidEcNumber("9312 1534")); // spaces within digits
 
         // EP: valid phone numbers
         assertTrue(EcNumber.isValidEcNumber("")); // Boundary value: empty string
-        assertTrue(EcNumber.isValidEcNumber("93121534")); // Boundary value: exactly 8 numbers
+        assertTrue(EcNumber.isValidEcNumber("123")); // Boundary value: 3 digits
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -35,7 +35,7 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_SEX = "H";
     private static final String INVALID_STUDENT_CLASS = "A1";
     private static final String INVALID_ECNAME = "---";
-    private static final String INVALID_ECNUMBER = "123";
+    private static final String INVALID_ECNUMBER = "+123";
     private static final String INVALID_SUBMISSION_NAME = "Assignment #";
     private static final String INVALID_SUBMISSION_STATUS = "T";
     private static final String INVALID_EXAM_NAME = "Midterm%";


### PR DESCRIPTION
addEcNumber command can only accept 8 digit numbers, and would reject numbers that has less or more than 8 digits. There are some phone numbers that might be less than or more than 8 digits that are valid phone numbers.

Fixed addEcNumber to accept numbers with at least 3 digits, as to not reject valid inputs.

Error message is then incorrect. Error message is updated accordingly in the same commit 1ca2389.

Fixes #309.